### PR TITLE
implemented get route for announcements

### DIFF
--- a/backend/controllers/announcement.controller.js
+++ b/backend/controllers/announcement.controller.js
@@ -1,0 +1,17 @@
+import Announcement from "../models/announcement.js";
+
+export const getAnnouncements = async (req, res) => {
+  try {
+    const announcements = await Announcement.find().sort({ date: -1 });
+    const formatted = announcements.map(a => ({
+      title: a.title,
+      description: a.description,
+      date: a.date,
+      link: a.link || null,
+    }));
+    return res.status(200).json({ announcements: formatted });
+  } catch (error) {
+    console.error('Error fetching announcements:', error);
+    return res.status(500).json({ message: 'Error fetching announcements', error });
+  }
+};

--- a/backend/models/announcement.js
+++ b/backend/models/announcement.js
@@ -1,0 +1,31 @@
+import mongoose from 'mongoose';
+
+const announcementSchema = new mongoose.Schema({
+  title: {
+    type: String,
+    required: true,
+    trim: true,
+  },
+  description: {
+    type: String,
+    required: true,
+    trim: true,
+  },
+  date: {
+    type: Date,
+    required: true,
+  },
+  link: {
+    type: String,
+    required: false,
+    trim: true,
+  },
+  createdAt: {
+    type: Date,
+    default: Date.now,
+  },
+});
+
+const Announcement = mongoose.model('Announcement', announcementSchema);
+
+export default Announcement;

--- a/backend/routes/user.routes.js
+++ b/backend/routes/user.routes.js
@@ -3,6 +3,7 @@ import { getHomePageData } from '../controllers/homePage.controller.js'; // Impo
 import { getAllClub, getClubById } from '../controllers/club.controller.js';
 import { getContacts } from '../controllers/contact.controller.js';
 import { getAll, getEventById } from '../controllers/event.controller.js';
+import { getAnnouncements } from '../controllers/announcement.controller.js';
 
 const router = express.Router();
 
@@ -16,5 +17,6 @@ router.get('/event:id', getEventById);
 router.get('/contacts', getContacts);
 router.get('/allClubs' , getAllClub);
 router.get('/allevents' , getAll);
+router.get('/announcements', getAnnouncements)
 
 export default router;


### PR DESCRIPTION
##### Announcements API Endpoint
##### Fixes
fixes #38 
##### Overview
- Added a new GET `/announcements` route to fetch and serve all announcements from the database for the frontend Announcements Page.

##### Implementation Details
- Created a Mongoose model for announcements with fields: `title`, `description`, `date`, and optional `link`.
- Implemented a controller to retrieve all announcements, sorted by most recent date.
- Registered the route in `user.routes.js` and ensured it is connected in the backend entrypoint.
- Added error handling for database/query failures.
- CORS is enabled for frontend integration.

##### API Response Example
```json
{
  "announcements": [
    {
      "title": "Sample Announcement",
      "description": "Details about the announcement.",
      "date": "2025-10-18T00:00:00.000Z",
      "link": "https://example.com"
    }
  ]
}

